### PR TITLE
isometric type bugfix

### DIFF
--- a/src/Isometric.js
+++ b/src/Isometric.js
@@ -41,11 +41,11 @@
  * 
  * @constructor
  * @param {Phaser.Game} game The current game instance.
- * @param {number} isometricType - the isometric projection anglye to use.
+ * @param {number} isometricType - the isometric projection angle to use.
  */
 Phaser.Plugin.Isometric = function (game, parent, isometricType) {
 
-    isometricType = isometricType || Phaser.Plugin.Isometric.CLASSIC
+    isometricType = isometricType || Phaser.Plugin.Isometric.CLASSIC;
 
     Phaser.Plugin.call(this, game, parent);
     this.projector = new Phaser.Plugin.Isometric.Projector(this.game, isometricType);

--- a/src/Isometric.js
+++ b/src/Isometric.js
@@ -41,11 +41,14 @@
  * 
  * @constructor
  * @param {Phaser.Game} game The current game instance.
+ * @param {number} isometricType - the isometric projection anglye to use.
  */
-Phaser.Plugin.Isometric = function (game, parent) {
+Phaser.Plugin.Isometric = function (game, parent, isometricType) {
+
+    isometricType = isometricType || Phaser.Plugin.Isometric.CLASSIC
 
     Phaser.Plugin.call(this, game, parent);
-    this.projector = new Phaser.Plugin.Isometric.Projector(this.game, Phaser.Plugin.Isometric.CLASSIC);
+    this.projector = new Phaser.Plugin.Isometric.Projector(this.game, isometricType);
     //  Add an instance of Isometric.Projector to game.iso if it doesn't exist already
     this.game.iso = this.game.iso || this.projector;
 };


### PR DESCRIPTION
I found out that when using sprites the images overlap each other.
That was because Phaser.Plugin.Isometric.CLASSIC was always used for the projector. While i had a sprite of a width of 64 and height of 32. (Isosprite of 32 by 32)
And instead using Phaser.Plugin.Isometric.ISOMETRIC did the trick, but it was not possible to initialize the plugin with a different setting then "Phaser.Plugin.Isometric.CLASSIC".

Which i think it should be configurable anyway.

Great plugin! 
Cheers