### PR TITLE
Consider adding a "main" field to your "package.json".

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-watch": "*",
     "grunt-jsdoc": "~0.5.6"
-  }
+  },
+  "main": "dist/phaser-plugin-isometric.js"
 }


### PR DESCRIPTION
Hi. With that, developers that use Browserify (and the likes) in their game projects may benefit from using your plugin like any regular Node.js package.json, installing it as a dependency.
